### PR TITLE
Fix BrokerFailureIT flanky test.

### DIFF
--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/integration/BrokerFailureIT.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/integration/BrokerFailureIT.java
@@ -39,6 +39,8 @@ public class BrokerFailureIT extends BaseIT {
 
   /**
    * Evaluate that a Publisher/Subscriber can survive a broker failure.
+   *
+   * @throws Exception
    */
   @Test(timeout = 300000)
   public void testBrokerUpDownUp() throws Exception {

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/integration/rule/KafkaRule.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/integration/rule/KafkaRule.java
@@ -76,13 +76,13 @@ public class KafkaRule extends ExternalResource {
   @Override
   protected void before() throws Throwable {
     for (int nodeId = INIT_NODE_ID; nodeId < replicationFactor; nodeId++) {
-      start(nodeId);
+      create(nodeId);
     }
   }
 
   @Override
   protected void after() {
-    kafkaServers.keySet().forEach(this::shutdown);
+    kafkaServers.keySet().forEach(this::destroy);
   }
 
   public void createTopic(String name) throws Exception {
@@ -145,16 +145,24 @@ public class KafkaRule extends ExternalResource {
 
   public void shutdown(Integer nodeId) {
     kafkaServers.get(nodeId).shutdown();
+  }
+
+  public void destroy(Integer nodeId) {
+    this.shutdown(nodeId);
     kafkaServers.remove(nodeId);
   }
 
-  public void start(Integer nodeId) throws Exception {
+  public void start(Integer nodeId) {
+    kafkaServers.get(nodeId).start();
+  }
+
+  public void create(Integer nodeId) throws Exception {
     if (kafkaServers.containsKey(nodeId)) {
       throw new IllegalArgumentException("NodeId already exists");
     }
 
     EmbeddedKafka embeddedKafka =
-        EmbeddedKafka.builder(temporaryFolder, replicationFactor, zkConnect).start(nodeId);
+        EmbeddedKafka.builder(temporaryFolder, replicationFactor, zkConnect).create(nodeId);
 
     kafkaServers.put(nodeId, embeddedKafka);
   }

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/integration/util/EmbeddedKafka.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/integration/util/EmbeddedKafka.java
@@ -73,7 +73,7 @@ public class EmbeddedKafka {
     return new EmbeddedKafka(temporaryFolder, replicationFactor, zkConnect);
   }
 
-  public EmbeddedKafka start(Integer nodeId) throws Exception {
+  public EmbeddedKafka create(Integer nodeId) throws Exception {
     int port = INIT_PORT + nodeId;
     String logDir = temporaryFolder.newFolder().getAbsolutePath();
 
@@ -83,6 +83,12 @@ public class EmbeddedKafka {
         new KafkaServer(kafkaConfig, Time.SYSTEM, Option.empty(), asScalaBuffer(new ArrayList<>()));
     kafkaServer.startup();
     return this;
+  }
+
+  public void start() {
+    if (kafkaServer.brokerState().currentState() == (NotRunning.state())) {
+      kafkaServer.startup();
+    }
   }
 
   public void shutdown() {


### PR DESCRIPTION
- Change to restart embedded kafka cluster instead of re-create on BrokerFailureIT.

The test fail, because on the moment we are re-creating embedded kafka cluster instead of restart, when recreating gives the possibility to publisher return repeated ids.