### PR TITLE
set empty PushConfig for Subscription in responses

### DIFF
--- a/src/main/java/com/google/cloud/partners/pubsub/kafka/SubscriberImpl.java
+++ b/src/main/java/com/google/cloud/partners/pubsub/kafka/SubscriberImpl.java
@@ -24,6 +24,7 @@ import com.google.cloud.partners.pubsub.kafka.properties.ConsumerProperties;
 import com.google.cloud.partners.pubsub.kafka.properties.KafkaProperties;
 import com.google.cloud.partners.pubsub.kafka.properties.SubscriptionProperties;
 import com.google.protobuf.Empty;
+import com.google.protobuf.UnknownFieldSet;
 import com.google.pubsub.v1.AcknowledgeRequest;
 import com.google.pubsub.v1.DeleteSubscriptionRequest;
 import com.google.pubsub.v1.GetSubscriptionRequest;
@@ -32,6 +33,7 @@ import com.google.pubsub.v1.ListSubscriptionsResponse;
 import com.google.pubsub.v1.ModifyAckDeadlineRequest;
 import com.google.pubsub.v1.PullRequest;
 import com.google.pubsub.v1.PullResponse;
+import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.ReceivedMessage;
 import com.google.pubsub.v1.StreamingPullRequest;
 import com.google.pubsub.v1.StreamingPullResponse;
@@ -324,6 +326,11 @@ class SubscriberImpl extends SubscriberImplBase {
     return Subscription.newBuilder()
         .setName(configuration.getName())
         .setTopic(configuration.getTopic())
+        .setPushConfig(
+            PushConfig.newBuilder()
+                .setPushEndpoint("")
+                .setUnknownFields(UnknownFieldSet.newBuilder().build())
+                .build())
         .setAckDeadlineSeconds(configuration.getAckDeadlineSeconds())
         .build();
   }

--- a/src/main/java/com/google/cloud/partners/pubsub/kafka/SubscriberImpl.java
+++ b/src/main/java/com/google/cloud/partners/pubsub/kafka/SubscriberImpl.java
@@ -24,7 +24,6 @@ import com.google.cloud.partners.pubsub.kafka.properties.ConsumerProperties;
 import com.google.cloud.partners.pubsub.kafka.properties.KafkaProperties;
 import com.google.cloud.partners.pubsub.kafka.properties.SubscriptionProperties;
 import com.google.protobuf.Empty;
-import com.google.protobuf.UnknownFieldSet;
 import com.google.pubsub.v1.AcknowledgeRequest;
 import com.google.pubsub.v1.DeleteSubscriptionRequest;
 import com.google.pubsub.v1.GetSubscriptionRequest;
@@ -326,11 +325,7 @@ class SubscriberImpl extends SubscriberImplBase {
     return Subscription.newBuilder()
         .setName(configuration.getName())
         .setTopic(configuration.getTopic())
-        .setPushConfig(
-            PushConfig.newBuilder()
-                .setPushEndpoint("")
-                .setUnknownFields(UnknownFieldSet.newBuilder().build())
-                .build())
+        .setPushConfig(PushConfig.getDefaultInstance())
         .setAckDeadlineSeconds(configuration.getAckDeadlineSeconds())
         .build();
   }


### PR DESCRIPTION
This PR fixes issue #9 . The emulator returns a `Subscription` with unset `PushConfig` attribute in response to `GetSubscription` calls.

Testing this fix with the program in issue #9 yields the expected result.
```
% export PUBSUB_EMULATOR_HOST=192.168.99.100:30555
% go run subscriber.go                                                                                
2018/11/19 21:00:58 {topic1 { map[]} 10s false 168h0m0s map[]}
``` 
Notice that this behavior is consistent with what GCP returns as PushConfig attribute:
```
% unset PUBSUB_EMULATOR_HOST
% go run subscriber.go      
2018/11/19 21:14:30 {projects/riccardomc-playground/topics/topic1 { map[]} 10s false 168h0m0s map[]}
```