### PR TITLE
Fix createSubscription and deleteSubscription when using formatted Topic and Subscriptions

### DIFF
--- a/src/main/java/com/google/cloud/partners/pubsub/kafka/SubscriberImpl.java
+++ b/src/main/java/com/google/cloud/partners/pubsub/kafka/SubscriberImpl.java
@@ -17,6 +17,7 @@
 package com.google.cloud.partners.pubsub.kafka;
 
 import static com.google.cloud.partners.pubsub.kafka.Configuration.getLastNodeInSubscription;
+import static com.google.cloud.partners.pubsub.kafka.Configuration.getLastNodeInTopic;
 import static java.lang.String.format;
 import static java.util.Objects.isNull;
 
@@ -160,7 +161,7 @@ class SubscriberImpl extends SubscriberImplBase {
   public void deleteSubscription(
       DeleteSubscriptionRequest request, StreamObserver<Empty> responseObserver) {
     try {
-      String subscription = Configuration.getLastNodeInSubscription(request.getSubscription());
+      String subscription = getLastNodeInSubscription(request.getSubscription());
       SubscriptionManager subscriptionManager =
           Optional.ofNullable(subscriptions.get(subscription))
               .orElseThrow(
@@ -336,20 +337,17 @@ class SubscriberImpl extends SubscriberImplBase {
   private SubscriptionProperties buildSubscriptionProperty(Subscription request) {
     SubscriptionProperties properties = new SubscriptionProperties();
     properties.setAckDeadlineSeconds(request.getAckDeadlineSeconds());
-    properties.setName(Configuration.getLastNodeInSubscription(request.getName()));
-    properties.setTopic(Configuration.getLastNodeInTopic(request.getTopic()));
+    properties.setName(getLastNodeInSubscription(request.getName()));
+    properties.setTopic(getLastNodeInTopic(request.getTopic()));
     return properties;
   }
 
   private void validateCreation(Subscription request) throws StatusException {
     KafkaProperties kafkaProperties = Configuration.getApplicationProperties().getKafkaProperties();
 
-    if (!kafkaProperties
-        .getTopics()
-        .contains(Configuration.getLastNodeInTopic(request.getTopic()))) {
+    if (!kafkaProperties.getTopics().contains(getLastNodeInTopic(request.getTopic()))) {
       throw Status.NOT_FOUND
-          .withDescription(
-              "Topic not found: " + Configuration.getLastNodeInTopic(request.getTopic()))
+          .withDescription("Topic not found: " + getLastNodeInTopic(request.getTopic()))
           .asException();
     }
 
@@ -362,7 +360,7 @@ class SubscriberImpl extends SubscriberImplBase {
             .map(Configuration::getLastNodeInSubscription)
             .collect(Collectors.toList());
 
-    if (subscriptions.contains(Configuration.getLastNodeInSubscription(request.getName()))) {
+    if (subscriptions.contains(getLastNodeInSubscription(request.getName()))) {
       throw Status.ALREADY_EXISTS.withDescription("Subscription already exists.").asException();
     }
   }

--- a/src/main/java/com/google/cloud/partners/pubsub/kafka/SubscriberImpl.java
+++ b/src/main/java/com/google/cloud/partners/pubsub/kafka/SubscriberImpl.java
@@ -136,25 +136,25 @@ class SubscriberImpl extends SubscriberImplBase {
       Subscription request, StreamObserver<Subscription> responseObserver) {
     try {
       validateCreation(request);
-      SubscriptionProperties subscriptionProperties = buildSubscriptionProperty(request);
-      Configuration.getApplicationProperties()
-          .getKafkaProperties()
-          .getConsumerProperties()
-          .getSubscriptions()
-          .add(subscriptionProperties);
-
-      SubscriptionManager subscriptionManager =
-          subscriptionManagerFactory.create(
-              subscriptionProperties, kafkaClientFactory, commitExecutorService);
-
-      subscriptions.put(subscriptionProperties.getName(), subscriptionManager);
-      statisticsManager.addSubscriberInformation(subscriptionProperties);
-
+      createSubscription(buildSubscriptionProperty(request));
       responseObserver.onNext(request);
       responseObserver.onCompleted();
     } catch (StatusException e) {
       responseObserver.onError(e);
     }
+  }
+
+  public void createSubscription(SubscriptionProperties subscriptionProperties) {
+    Configuration.getApplicationProperties()
+        .getKafkaProperties()
+        .getConsumerProperties()
+        .getSubscriptions()
+        .add(subscriptionProperties);
+    subscriptions.put(
+        subscriptionProperties.getName(),
+        subscriptionManagerFactory.create(
+            subscriptionProperties, kafkaClientFactory, commitExecutorService));
+    statisticsManager.addSubscriberInformation(subscriptionProperties);
   }
 
   @Override

--- a/src/main/java/com/google/cloud/partners/pubsub/kafka/SubscriberImpl.java
+++ b/src/main/java/com/google/cloud/partners/pubsub/kafka/SubscriberImpl.java
@@ -136,7 +136,7 @@ class SubscriberImpl extends SubscriberImplBase {
       Subscription request, StreamObserver<Subscription> responseObserver) {
     try {
       validateCreation(request);
-      createSubscription(buildSubscriptionProperty(request));
+      addSubscription(buildSubscriptionProperty(request));
       responseObserver.onNext(request);
       responseObserver.onCompleted();
     } catch (StatusException e) {
@@ -144,7 +144,7 @@ class SubscriberImpl extends SubscriberImplBase {
     }
   }
 
-  public void createSubscription(SubscriptionProperties subscriptionProperties) {
+  void addSubscription(SubscriptionProperties subscriptionProperties) {
     Configuration.getApplicationProperties()
         .getKafkaProperties()
         .getConsumerProperties()

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/SubscriberImplTest.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/SubscriberImplTest.java
@@ -91,7 +91,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-@FixMethodOrder(MethodSorters.NAME_ASCENDING) // FIXME: Delete must happen before List
 public class SubscriberImplTest {
 
   public static final String PROJECT_SUBSCRIPTION_FORMAT = "projects/%s/subscriptions/%s";

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/SubscriberImplTest.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/SubscriberImplTest.java
@@ -107,24 +107,6 @@ public class SubscriberImplTest {
   public static void setUpBeforeClass() {
 
     TestHelpers.useTestApplicationConfig(1, 1);
-
-    List<SubscriptionProperties> subscriptions =
-        Configuration.getApplicationProperties()
-            .getKafkaProperties()
-            .getConsumerProperties()
-            .getSubscriptions();
-
-    SubscriptionProperties subscriptionProperties1 = new SubscriptionProperties();
-    subscriptionProperties1.setTopic(TOPIC_TO_DELETE1);
-    subscriptionProperties1.setName(SUBSCRIPTION_TO_DELETE1);
-    subscriptionProperties1.setAckDeadlineSeconds(10);
-    subscriptions.add(subscriptionProperties1);
-
-    SubscriptionProperties subscriptionProperties2 = new SubscriptionProperties();
-    subscriptionProperties2.setTopic(TOPIC_TO_DELETE2);
-    subscriptionProperties2.setName(SUBSCRIPTION_TO_DELETE2_FORMATTED);
-    subscriptionProperties2.setAckDeadlineSeconds(10);
-    subscriptions.add(subscriptionProperties2);
   }
 
   @Before
@@ -134,12 +116,12 @@ public class SubscriberImplTest {
     kafkaClientFactory.configureConsumersForSubscription(TOPIC1, SUBSCRIPTION1, 3, 0L, 0L);
     kafkaClientFactory.configureConsumersForSubscription(TOPIC1, SUBSCRIPTION2, 3, 0L, 0L);
     kafkaClientFactory.configureConsumersForSubscription(TOPIC2, SUBSCRIPTION3, 3, 0L, 0L);
+    kafkaClientFactory.configureConsumersForSubscription(TOPIC1, NEW_SUBSCRIPTION1, 3, 0L, 0L);
+    kafkaClientFactory.configureConsumersForSubscription(TOPIC2, NEW_SUBSCRIPTION2, 3, 0L, 0L);
     kafkaClientFactory.configureConsumersForSubscription(
         TOPIC_TO_DELETE1, SUBSCRIPTION_TO_DELETE1, 3, 0L, 0L);
     kafkaClientFactory.configureConsumersForSubscription(
         TOPIC_TO_DELETE2, SUBSCRIPTION_TO_DELETE2_FORMATTED, 3, 0L, 0L);
-    kafkaClientFactory.configureConsumersForSubscription(TOPIC1, NEW_SUBSCRIPTION1, 3, 0L, 0L);
-    kafkaClientFactory.configureConsumersForSubscription(TOPIC2, NEW_SUBSCRIPTION2, 3, 0L, 0L);
 
     subscriptionManageFactory = new SpyingSubscriptionManageFactoryImpl();
     subscriber =
@@ -276,6 +258,12 @@ public class SubscriberImplTest {
   @Test
   public void deleteSubscription() {
     try {
+      SubscriptionProperties subscriptionToDelete = new SubscriptionProperties();
+      subscriptionToDelete.setTopic(TOPIC_TO_DELETE1);
+      subscriptionToDelete.setName(SUBSCRIPTION_TO_DELETE1);
+      subscriptionToDelete.setAckDeadlineSeconds(10);
+      subscriber.createSubscription(subscriptionToDelete);
+
       DeleteSubscriptionRequest request =
           DeleteSubscriptionRequest.newBuilder().setSubscription(SUBSCRIPTION_TO_DELETE1).build();
       blockingStub.deleteSubscription(request);
@@ -313,6 +301,12 @@ public class SubscriberImplTest {
   @Test
   public void deleteSubscriptionFormatted() {
     try {
+      SubscriptionProperties subscriptionToDelete = new SubscriptionProperties();
+      subscriptionToDelete.setTopic(TOPIC_TO_DELETE2);
+      subscriptionToDelete.setName(SUBSCRIPTION_TO_DELETE2_FORMATTED);
+      subscriptionToDelete.setAckDeadlineSeconds(10);
+      subscriber.createSubscription(subscriptionToDelete);
+
       DeleteSubscriptionRequest request =
           DeleteSubscriptionRequest.newBuilder()
               .setSubscription(SUBSCRIPTION_TO_DELETE2_FORMATTED)

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/SubscriberImplTest.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/SubscriberImplTest.java
@@ -82,11 +82,9 @@ import org.apache.kafka.clients.consumer.MockConsumer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.FixMethodOrder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.MethodSorters;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -261,7 +259,7 @@ public class SubscriberImplTest {
       subscriptionToDelete.setTopic(TOPIC_TO_DELETE1);
       subscriptionToDelete.setName(SUBSCRIPTION_TO_DELETE1);
       subscriptionToDelete.setAckDeadlineSeconds(10);
-      subscriber.createSubscription(subscriptionToDelete);
+      subscriber.addSubscription(subscriptionToDelete);
 
       DeleteSubscriptionRequest request =
           DeleteSubscriptionRequest.newBuilder().setSubscription(SUBSCRIPTION_TO_DELETE1).build();
@@ -304,7 +302,7 @@ public class SubscriberImplTest {
       subscriptionToDelete.setTopic(TOPIC_TO_DELETE2);
       subscriptionToDelete.setName(SUBSCRIPTION_TO_DELETE2_FORMATTED);
       subscriptionToDelete.setAckDeadlineSeconds(10);
-      subscriber.createSubscription(subscriptionToDelete);
+      subscriber.addSubscription(subscriptionToDelete);
 
       DeleteSubscriptionRequest request =
           DeleteSubscriptionRequest.newBuilder()

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/SubscriberImplTest.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/SubscriberImplTest.java
@@ -16,9 +16,21 @@
 
 package com.google.cloud.partners.pubsub.kafka;
 
+import static com.google.cloud.partners.pubsub.kafka.TestHelpers.NEW_SUBSCRIPTION1;
+import static com.google.cloud.partners.pubsub.kafka.TestHelpers.NEW_SUBSCRIPTION2;
+import static com.google.cloud.partners.pubsub.kafka.TestHelpers.NEW_SUBSCRIPTION2_FORMATTED;
 import static com.google.cloud.partners.pubsub.kafka.TestHelpers.PROJECT;
 import static com.google.cloud.partners.pubsub.kafka.TestHelpers.SUBSCRIPTION1;
+import static com.google.cloud.partners.pubsub.kafka.TestHelpers.SUBSCRIPTION2;
+import static com.google.cloud.partners.pubsub.kafka.TestHelpers.SUBSCRIPTION3;
 import static com.google.cloud.partners.pubsub.kafka.TestHelpers.SUBSCRIPTION_NOT_EXISTS;
+import static com.google.cloud.partners.pubsub.kafka.TestHelpers.SUBSCRIPTION_TO_DELETE1;
+import static com.google.cloud.partners.pubsub.kafka.TestHelpers.SUBSCRIPTION_TO_DELETE2_FORMATTED;
+import static com.google.cloud.partners.pubsub.kafka.TestHelpers.TOPIC1;
+import static com.google.cloud.partners.pubsub.kafka.TestHelpers.TOPIC2;
+import static com.google.cloud.partners.pubsub.kafka.TestHelpers.TOPIC2_FORMATTED;
+import static com.google.cloud.partners.pubsub.kafka.TestHelpers.TOPIC_TO_DELETE1;
+import static com.google.cloud.partners.pubsub.kafka.TestHelpers.TOPIC_TO_DELETE2;
 import static java.lang.String.format;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
@@ -32,6 +44,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.google.cloud.partners.pubsub.kafka.properties.SubscriptionProperties;
+import com.google.common.collect.Lists;
 import com.google.protobuf.Empty;
 import com.google.protobuf.Timestamp;
 import com.google.pubsub.v1.AcknowledgeRequest;
@@ -69,18 +82,20 @@ import org.apache.kafka.clients.consumer.MockConsumer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING) // FIXME: Delete must happen before List
 public class SubscriberImplTest {
 
   public static final String PROJECT_SUBSCRIPTION_FORMAT = "projects/%s/subscriptions/%s";
   private static final String MESSAGE_CONTENT_REGEX = "message-[0-9]{4}";
-  private static final String NEW_SUBSCRIPTION = "new-subscription";
   @Rule public final GrpcServerRule grpcServerRule = new GrpcServerRule();
   private SubscriberGrpc.SubscriberBlockingStub blockingStub;
   private MockKafkaClientFactoryImpl kafkaClientFactory;
@@ -93,32 +108,38 @@ public class SubscriberImplTest {
 
     TestHelpers.useTestApplicationConfig(1, 1);
 
-    SubscriptionProperties subscriptionProperties = new SubscriptionProperties();
-    subscriptionProperties.setTopic(TestHelpers.TOPIC_TO_DELETE);
-    subscriptionProperties.setName(TestHelpers.SUBSCRIPTION_TO_DELETE);
-    subscriptionProperties.setAckDeadlineSeconds(10);
+    List<SubscriptionProperties> subscriptions =
+        Configuration.getApplicationProperties()
+            .getKafkaProperties()
+            .getConsumerProperties()
+            .getSubscriptions();
 
-    Configuration.getApplicationProperties()
-        .getKafkaProperties()
-        .getConsumerProperties()
-        .getSubscriptions()
-        .add(subscriptionProperties);
+    SubscriptionProperties subscriptionProperties1 = new SubscriptionProperties();
+    subscriptionProperties1.setTopic(TOPIC_TO_DELETE1);
+    subscriptionProperties1.setName(SUBSCRIPTION_TO_DELETE1);
+    subscriptionProperties1.setAckDeadlineSeconds(10);
+    subscriptions.add(subscriptionProperties1);
+
+    SubscriptionProperties subscriptionProperties2 = new SubscriptionProperties();
+    subscriptionProperties2.setTopic(TOPIC_TO_DELETE2);
+    subscriptionProperties2.setName(SUBSCRIPTION_TO_DELETE2_FORMATTED);
+    subscriptionProperties2.setAckDeadlineSeconds(10);
+    subscriptions.add(subscriptionProperties2);
   }
 
   @Before
   public void setUp() {
     TestHelpers.setupRequestBindConfiguration();
     kafkaClientFactory = new MockKafkaClientFactoryImpl();
+    kafkaClientFactory.configureConsumersForSubscription(TOPIC1, SUBSCRIPTION1, 3, 0L, 0L);
+    kafkaClientFactory.configureConsumersForSubscription(TOPIC1, SUBSCRIPTION2, 3, 0L, 0L);
+    kafkaClientFactory.configureConsumersForSubscription(TOPIC2, SUBSCRIPTION3, 3, 0L, 0L);
     kafkaClientFactory.configureConsumersForSubscription(
-        TestHelpers.TOPIC1, SUBSCRIPTION1, 3, 0L, 0L);
+        TOPIC_TO_DELETE1, SUBSCRIPTION_TO_DELETE1, 3, 0L, 0L);
     kafkaClientFactory.configureConsumersForSubscription(
-        TestHelpers.TOPIC1, TestHelpers.SUBSCRIPTION2, 3, 0L, 0L);
-    kafkaClientFactory.configureConsumersForSubscription(
-        TestHelpers.TOPIC2, TestHelpers.SUBSCRIPTION3, 3, 0L, 0L);
-    kafkaClientFactory.configureConsumersForSubscription(
-        TestHelpers.TOPIC_TO_DELETE, TestHelpers.SUBSCRIPTION_TO_DELETE, 3, 0L, 0L);
-    kafkaClientFactory.configureConsumersForSubscription(
-        TestHelpers.TOPIC1, NEW_SUBSCRIPTION, 3, 0L, 0L);
+        TOPIC_TO_DELETE2, SUBSCRIPTION_TO_DELETE2_FORMATTED, 3, 0L, 0L);
+    kafkaClientFactory.configureConsumersForSubscription(TOPIC1, NEW_SUBSCRIPTION1, 3, 0L, 0L);
+    kafkaClientFactory.configureConsumersForSubscription(TOPIC2, NEW_SUBSCRIPTION2, 3, 0L, 0L);
 
     subscriptionManageFactory = new SpyingSubscriptionManageFactoryImpl();
     subscriber =
@@ -129,11 +150,13 @@ public class SubscriberImplTest {
 
   @After
   public void tearDown() {
-    Configuration.getApplicationProperties()
-        .getKafkaProperties()
-        .getConsumerProperties()
-        .getSubscriptions()
-        .removeIf(s -> NEW_SUBSCRIPTION.equals(s.getName()));
+    List<String> toRemove = Lists.newArrayList(NEW_SUBSCRIPTION1, NEW_SUBSCRIPTION2);
+    List<SubscriptionProperties> l =
+        Configuration.getApplicationProperties()
+            .getKafkaProperties()
+            .getConsumerProperties()
+            .getSubscriptions();
+    l.removeIf(s -> toRemove.contains(s.getName()));
 
     TestHelpers.resetRequestBindConfiguration();
   }
@@ -145,10 +168,10 @@ public class SubscriberImplTest {
         .getConsumersForSubscription(SUBSCRIPTION1)
         .forEach(c -> assertTrue(c.closed()));
     kafkaClientFactory
-        .getConsumersForSubscription(TestHelpers.SUBSCRIPTION2)
+        .getConsumersForSubscription(SUBSCRIPTION2)
         .forEach(c -> assertTrue(c.closed()));
     kafkaClientFactory
-        .getConsumersForSubscription(TestHelpers.SUBSCRIPTION3)
+        .getConsumersForSubscription(SUBSCRIPTION3)
         .forEach(c -> assertTrue(c.closed()));
   }
 
@@ -176,7 +199,7 @@ public class SubscriberImplTest {
       Subscription request =
           Subscription.newBuilder()
               .setName(SUBSCRIPTION1)
-              .setTopic(TestHelpers.TOPIC1)
+              .setTopic(TOPIC1)
               .setAckDeadlineSeconds(10)
               .build();
       blockingStub.createSubscription(request);
@@ -189,14 +212,14 @@ public class SubscriberImplTest {
   }
 
   @Test
-  public void createSubscription() {
+  public void createSubscriptionFormatted() {
     try {
       int ack = 10;
 
       Subscription request =
           Subscription.newBuilder()
-              .setName(NEW_SUBSCRIPTION)
-              .setTopic(TestHelpers.TOPIC1)
+              .setName(NEW_SUBSCRIPTION2_FORMATTED)
+              .setTopic(TOPIC2_FORMATTED)
               .setAckDeadlineSeconds(ack)
               .build();
       blockingStub.createSubscription(request);
@@ -207,11 +230,42 @@ public class SubscriberImplTest {
               .getConsumerProperties()
               .getSubscriptions()
               .stream()
-              .filter(s -> s.getName().equals(NEW_SUBSCRIPTION))
+              .filter(s -> s.getName().equals(NEW_SUBSCRIPTION2))
               .findFirst()
               .orElseThrow(() -> new Exception("Fail get property information."));
 
-      assertEquals(TestHelpers.TOPIC1, subscriptionProperties.getTopic());
+      assertEquals(TOPIC2, subscriptionProperties.getTopic());
+      assertEquals(ack, subscriptionProperties.getAckDeadlineSeconds());
+      verify(statisticsManager).addSubscriberInformation(subscriptionProperties);
+    } catch (Exception e) {
+      fail("Unexpected exception thrown " + e.getMessage());
+    }
+  }
+
+  @Test
+  public void createSubscription() {
+    try {
+      int ack = 10;
+
+      Subscription request =
+          Subscription.newBuilder()
+              .setName(NEW_SUBSCRIPTION1)
+              .setTopic(TOPIC1)
+              .setAckDeadlineSeconds(ack)
+              .build();
+      blockingStub.createSubscription(request);
+
+      SubscriptionProperties subscriptionProperties =
+          Configuration.getApplicationProperties()
+              .getKafkaProperties()
+              .getConsumerProperties()
+              .getSubscriptions()
+              .stream()
+              .filter(s -> s.getName().equals(NEW_SUBSCRIPTION1))
+              .findFirst()
+              .orElseThrow(() -> new Exception("Fail get property information."));
+
+      assertEquals(TOPIC1, subscriptionProperties.getTopic());
       assertEquals(ack, subscriptionProperties.getAckDeadlineSeconds());
       verify(statisticsManager).addSubscriberInformation(subscriptionProperties);
     } catch (Exception e) {
@@ -223,9 +277,7 @@ public class SubscriberImplTest {
   public void deleteSubscription() {
     try {
       DeleteSubscriptionRequest request =
-          DeleteSubscriptionRequest.newBuilder()
-              .setSubscription(TestHelpers.SUBSCRIPTION_TO_DELETE)
-              .build();
+          DeleteSubscriptionRequest.newBuilder().setSubscription(SUBSCRIPTION_TO_DELETE1).build();
       blockingStub.deleteSubscription(request);
 
       assertEquals(
@@ -236,11 +288,10 @@ public class SubscriberImplTest {
               .getSubscriptions()
               .stream()
               .filter(
-                  subscriptionProperties ->
-                      subscriptionProperties.equals(TestHelpers.SUBSCRIPTION_TO_DELETE))
+                  subscriptionProperties -> subscriptionProperties.equals(SUBSCRIPTION_TO_DELETE1))
               .count());
 
-      verify(statisticsManager).removeSubscriberInformation(TestHelpers.TOPIC_TO_DELETE);
+      verify(statisticsManager).removeSubscriberInformation(TOPIC_TO_DELETE1);
     } catch (StatusRuntimeException e) {
       fail("Unexpected exception thrown " + e.getMessage());
     }
@@ -260,12 +311,39 @@ public class SubscriberImplTest {
   }
 
   @Test
+  public void deleteSubscriptionFormatted() {
+    try {
+      DeleteSubscriptionRequest request =
+          DeleteSubscriptionRequest.newBuilder()
+              .setSubscription(SUBSCRIPTION_TO_DELETE2_FORMATTED)
+              .build();
+      blockingStub.deleteSubscription(request);
+
+      assertEquals(
+          0,
+          Configuration.getApplicationProperties()
+              .getKafkaProperties()
+              .getConsumerProperties()
+              .getSubscriptions()
+              .stream()
+              .filter(
+                  subscriptionProperties ->
+                      subscriptionProperties.equals(SUBSCRIPTION_TO_DELETE2_FORMATTED))
+              .count());
+
+      verify(statisticsManager).removeSubscriberInformation(TOPIC_TO_DELETE2);
+    } catch (StatusRuntimeException e) {
+      fail("Unexpected exception thrown " + e.getMessage());
+    }
+  }
+
+  @Test
   public void getSubscriptionExists() {
     GetSubscriptionRequest request =
         GetSubscriptionRequest.newBuilder().setSubscription(SUBSCRIPTION1).build();
     Subscription response = blockingStub.getSubscription(request);
     assertEquals(SUBSCRIPTION1, response.getName());
-    assertEquals(TestHelpers.TOPIC1, response.getTopic());
+    assertEquals(TOPIC1, response.getTopic());
     assertEquals(10, response.getAckDeadlineSeconds());
   }
 
@@ -289,15 +367,15 @@ public class SubscriberImplTest {
     ListSubscriptionsResponse response = blockingStub.listSubscriptions(request);
     assertEquals(3, response.getSubscriptionsCount());
     assertEquals(SUBSCRIPTION1, response.getSubscriptions(0).getName());
-    assertEquals(TestHelpers.TOPIC1, response.getSubscriptions(0).getTopic());
+    assertEquals(TOPIC1, response.getSubscriptions(0).getTopic());
     assertEquals(10, response.getSubscriptions(0).getAckDeadlineSeconds());
 
-    assertEquals(TestHelpers.SUBSCRIPTION3, response.getSubscriptions(1).getName());
-    assertEquals(TestHelpers.TOPIC2, response.getSubscriptions(1).getTopic());
+    assertEquals(SUBSCRIPTION3, response.getSubscriptions(1).getName());
+    assertEquals(TOPIC2, response.getSubscriptions(1).getTopic());
     assertEquals(60, response.getSubscriptions(1).getAckDeadlineSeconds());
 
-    assertEquals(TestHelpers.SUBSCRIPTION2, response.getSubscriptions(2).getName());
-    assertEquals(TestHelpers.TOPIC1, response.getSubscriptions(2).getTopic());
+    assertEquals(SUBSCRIPTION2, response.getSubscriptions(2).getName());
+    assertEquals(TOPIC1, response.getSubscriptions(2).getTopic());
     assertEquals(10, response.getSubscriptions(2).getAckDeadlineSeconds());
 
     assertTrue(response.getNextPageToken().isEmpty());
@@ -312,7 +390,7 @@ public class SubscriberImplTest {
 
     assertEquals(1, response.getSubscriptionsCount());
     assertEquals(SUBSCRIPTION1, response.getSubscriptions(0).getName());
-    assertEquals(TestHelpers.TOPIC1, response.getSubscriptions(0).getTopic());
+    assertEquals(TOPIC1, response.getSubscriptions(0).getTopic());
     assertEquals(10, response.getSubscriptions(0).getAckDeadlineSeconds());
     assertFalse(response.getNextPageToken().isEmpty());
 
@@ -324,8 +402,8 @@ public class SubscriberImplTest {
                 .build());
 
     assertEquals(1, responseForSecondPage.getSubscriptionsCount());
-    assertEquals(TestHelpers.SUBSCRIPTION3, responseForSecondPage.getSubscriptions(0).getName());
-    assertEquals(TestHelpers.TOPIC2, responseForSecondPage.getSubscriptions(0).getTopic());
+    assertEquals(SUBSCRIPTION3, responseForSecondPage.getSubscriptions(0).getName());
+    assertEquals(TOPIC2, responseForSecondPage.getSubscriptions(0).getTopic());
     assertEquals(60, responseForSecondPage.getSubscriptions(0).getAckDeadlineSeconds());
     assertFalse(responseForSecondPage.getNextPageToken().isEmpty());
 
@@ -336,16 +414,10 @@ public class SubscriberImplTest {
                 .setPageToken(responseForSecondPage.getNextPageToken())
                 .build());
 
-    assertEquals(2, responseForThirdPage.getSubscriptionsCount());
-    assertEquals(TestHelpers.SUBSCRIPTION2, responseForThirdPage.getSubscriptions(0).getName());
-    assertEquals(TestHelpers.TOPIC1, responseForThirdPage.getSubscriptions(0).getTopic());
+    assertEquals(1, responseForThirdPage.getSubscriptionsCount());
+    assertEquals(SUBSCRIPTION2, responseForThirdPage.getSubscriptions(0).getName());
+    assertEquals(TOPIC1, responseForThirdPage.getSubscriptions(0).getTopic());
     assertEquals(10, responseForThirdPage.getSubscriptions(0).getAckDeadlineSeconds());
-
-    assertEquals(
-        TestHelpers.SUBSCRIPTION_TO_DELETE, responseForThirdPage.getSubscriptions(1).getName());
-    assertEquals(TestHelpers.TOPIC_TO_DELETE, responseForThirdPage.getSubscriptions(1).getTopic());
-    assertEquals(10, responseForThirdPage.getSubscriptions(1).getAckDeadlineSeconds());
-    assertTrue(responseForThirdPage.getNextPageToken().isEmpty());
   }
 
   @Test
@@ -379,7 +451,7 @@ public class SubscriberImplTest {
     int recordsPerPartition = 2;
     MockConsumer<String, ByteBuffer> mockConsumer =
         kafkaClientFactory.getConsumersForSubscription(SUBSCRIPTION1).get(0);
-    TestHelpers.generateConsumerRecords(TestHelpers.TOPIC1, partitions, recordsPerPartition, null)
+    TestHelpers.generateConsumerRecords(TOPIC1, partitions, recordsPerPartition, null)
         .forEach(mockConsumer::addRecord);
 
     PullRequest request =
@@ -430,7 +502,7 @@ public class SubscriberImplTest {
     int recordsPerPartition = 2;
     MockConsumer<String, ByteBuffer> mockConsumer =
         kafkaClientFactory.getConsumersForSubscription(SUBSCRIPTION1).get(0);
-    TestHelpers.generateConsumerRecords(TestHelpers.TOPIC1, partitions, recordsPerPartition, null)
+    TestHelpers.generateConsumerRecords(TOPIC1, partitions, recordsPerPartition, null)
         .forEach(mockConsumer::addRecord);
 
     PullRequest request =
@@ -503,7 +575,7 @@ public class SubscriberImplTest {
     int concurrentClients = 3;
     MockConsumer<String, ByteBuffer> mockConsumer =
         kafkaClientFactory.getConsumersForSubscription(SUBSCRIPTION1).get(0);
-    TestHelpers.generateConsumerRecords(TestHelpers.TOPIC1, partitions, recordsPerPartition, null)
+    TestHelpers.generateConsumerRecords(TOPIC1, partitions, recordsPerPartition, null)
         .forEach(mockConsumer::addRecord);
 
     CountDownLatch countDownLatch = new CountDownLatch(concurrentClients);
@@ -691,7 +763,7 @@ public class SubscriberImplTest {
     int recordsPerPartition = 2;
     MockConsumer<String, ByteBuffer> mockConsumer =
         kafkaClientFactory.getConsumersForSubscription(SUBSCRIPTION1).get(0);
-    TestHelpers.generateConsumerRecords(TestHelpers.TOPIC1, partitions, recordsPerPartition, null)
+    TestHelpers.generateConsumerRecords(TOPIC1, partitions, recordsPerPartition, null)
         .forEach(mockConsumer::addRecord);
 
     CompletableFuture<StreamingPullResponse> streamingFuture = new CompletableFuture<>();
@@ -734,7 +806,7 @@ public class SubscriberImplTest {
     int recordsPerPartition = 2;
     MockConsumer<String, ByteBuffer> mockConsumer =
         kafkaClientFactory.getConsumersForSubscription(SUBSCRIPTION1).get(0);
-    TestHelpers.generateConsumerRecords(TestHelpers.TOPIC1, partitions, recordsPerPartition, null)
+    TestHelpers.generateConsumerRecords(TOPIC1, partitions, recordsPerPartition, null)
         .forEach(mockConsumer::addRecord);
 
     CompletableFuture<StreamingPullResponse> streamingFuture = new CompletableFuture<>();
@@ -806,7 +878,7 @@ public class SubscriberImplTest {
     int recordsPerPartition = 2;
     MockConsumer<String, ByteBuffer> mockConsumer =
         kafkaClientFactory.getConsumersForSubscription(SUBSCRIPTION1).get(0);
-    TestHelpers.generateConsumerRecords(TestHelpers.TOPIC1, partitions, recordsPerPartition, null)
+    TestHelpers.generateConsumerRecords(TOPIC1, partitions, recordsPerPartition, null)
         .forEach(mockConsumer::addRecord);
 
     CompletableFuture<StreamingPullResponse> streamingFuture = new CompletableFuture<>();
@@ -878,7 +950,7 @@ public class SubscriberImplTest {
     int recordsPerPartition = 2;
     MockConsumer<String, ByteBuffer> mockConsumer =
         kafkaClientFactory.getConsumersForSubscription(SUBSCRIPTION1).get(0);
-    TestHelpers.generateConsumerRecords(TestHelpers.TOPIC1, partitions, recordsPerPartition, null)
+    TestHelpers.generateConsumerRecords(TOPIC1, partitions, recordsPerPartition, null)
         .forEach(mockConsumer::addRecord);
 
     CompletableFuture<StreamingPullResponse> streamingFuture = new CompletableFuture<>();
@@ -932,7 +1004,7 @@ public class SubscriberImplTest {
     int recordsPerPartition = 2;
     MockConsumer<String, ByteBuffer> mockConsumer =
         kafkaClientFactory.getConsumersForSubscription(SUBSCRIPTION1).get(0);
-    TestHelpers.generateConsumerRecords(TestHelpers.TOPIC1, partitions, recordsPerPartition, null)
+    TestHelpers.generateConsumerRecords(TOPIC1, partitions, recordsPerPartition, null)
         .forEach(mockConsumer::addRecord);
 
     CompletableFuture<StreamingPullResponse> streamingFuture = new CompletableFuture<>();

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/TestHelpers.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/TestHelpers.java
@@ -37,16 +37,25 @@ import org.apache.kafka.common.record.TimestampType;
 public class TestHelpers {
 
   public static final Charset UTF8 = Charset.forName("UTF-8");
+  protected static final String PROJECT = "cpe-ti";
   public static final String SUBSCRIPTION1 = "subscription-1-to-test-topic-1";
   public static final String SUBSCRIPTION2 = "subscription-2-to-test-topic-1";
   public static final String SUBSCRIPTION3 = "subscription-1-to-test-topic-2";
+  public static final String NEW_SUBSCRIPTION1 = "new-subscription1";
+  public static final String NEW_SUBSCRIPTION2 = "new-subscription2";
+  public static final String NEW_SUBSCRIPTION2_FORMATTED =
+      "projects/cpe-ti/subscriptions/new-subscription2";
   public static final String SUBSCRIPTION_NOT_EXISTS = "non-existent-subscription";
-  public static final String SUBSCRIPTION_TO_DELETE = "subscription-to-delete";
+  public static final String SUBSCRIPTION_TO_DELETE1 = "subscription-to-delete-1";
+  public static final String SUBSCRIPTION_TO_DELETE2 = "subscription-to-delete-2";
+  public static final String SUBSCRIPTION_TO_DELETE2_FORMATTED =
+      "projects/cpe-ti/subscriptions/subscription-to-delete-2";
   public static final String TOPIC1 = "test-topic-1";
   public static final String TOPIC2 = "test-topic-2";
-  public static final String TOPIC_TO_DELETE = "topic-to-delete";
-  public static final String TOPIC_NOT_EXISTS = "non-existent-topic";
-  protected static final String PROJECT = "cpe-ti";
+  public static final String TOPIC2_FORMATTED = "projects/cpe-ti/topics/test-topic-2";
+  public static final String TOPIC_TO_DELETE1 = "topic-to-delete1";
+  public static final String TOPIC_TO_DELETE2 = "topic-to-delete2";
+  static final String TOPIC_NOT_EXISTS = "non-existent-topic";
   private static final String CONFIGURATION_UNIT_TEST =
       "src/test/resources/application-unit-test.yaml";
 
@@ -122,7 +131,12 @@ public class TestHelpers {
 
   protected static void setupRequestBindConfiguration() {
     Map<String, List<PubSubBindProperties>> pubSubProperties = newHashMap();
-    pubSubProperties.put(PROJECT, newArrayList(givenPubSubBindProperty(SUBSCRIPTION1, TOPIC2)));
+    pubSubProperties.put(
+        PROJECT,
+        newArrayList(
+            givenPubSubBindProperty(SUBSCRIPTION1, TOPIC2),
+            givenPubSubBindProperty(NEW_SUBSCRIPTION2, TOPIC2),
+            givenPubSubBindProperty(SUBSCRIPTION_TO_DELETE2_FORMATTED, TOPIC_TO_DELETE2)));
     Configuration.getApplicationProperties().setPubSubProperties(pubSubProperties);
   }
 

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/TestHelpers.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/TestHelpers.java
@@ -55,7 +55,7 @@ public class TestHelpers {
   public static final String TOPIC2_FORMATTED = "projects/cpe-ti/topics/test-topic-2";
   public static final String TOPIC_TO_DELETE1 = "topic-to-delete1";
   public static final String TOPIC_TO_DELETE2 = "topic-to-delete2";
-  static final String TOPIC_NOT_EXISTS = "non-existent-topic";
+  public static final String TOPIC_NOT_EXISTS = "non-existent-topic";
   private static final String CONFIGURATION_UNIT_TEST =
       "src/test/resources/application-unit-test.yaml";
 


### PR DESCRIPTION
This PR fixes issue #11. It simply introduces `Configuration::getLastNodeInSubscription` and `Configuration::getLastNodeInTopic` where necessary.

I've introduce two tests to check create and delete request with formatted Topic and Subscription names.

Please notice that the program in issue #11, works as expected both on GCP and with the emulator:
```
% export PUBSUB_EMULATOR_HOST=192.168.99.100:30555
% go run subscriber2.go ; echo $?                 
0
```

While the change set seems big, a lot of them are just a minor refactoring of `SubscriberImplTest.java`. I was not happy with the mess introduced by the additional variables required by `deleteSubscriptionFormatted` and `createSubscriptionFormatted`.