### PR TITLE
Implement create/delete topics

### DIFF
--- a/src/main/java/com/google/cloud/partners/pubsub/kafka/properties/SubscriptionProperties.java
+++ b/src/main/java/com/google/cloud/partners/pubsub/kafka/properties/SubscriptionProperties.java
@@ -18,6 +18,9 @@ package com.google.cloud.partners.pubsub.kafka.properties;
 
 public class SubscriptionProperties {
 
+  // http://googleapis.github.io/googleapis/java/grpc-google-cloud-pubsub-v1/0.1.5/apidocs/com/google/pubsub/v1/PublisherGrpc.PublisherImplBase.html#deleteTopic-com.google.pubsub.v1.DeleteTopicRequest-io.grpc.stub.StreamObserver-
+  private final String DELETED_TOPIC = "_deleted_topic_";
+
   private String name;
 
   private String topic;
@@ -38,6 +41,14 @@ public class SubscriptionProperties {
 
   public void setTopic(String topic) {
     this.topic = topic;
+  }
+
+  public void setDeletedTopic() {
+    setTopic(DELETED_TOPIC);
+  }
+
+  public boolean hasDeletedTopic() {
+    return topic.equals(DELETED_TOPIC);
   }
 
   public int getAckDeadlineSeconds() {

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/PublisherImplTest.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/PublisherImplTest.java
@@ -22,15 +22,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.*;
 
+import com.google.cloud.partners.pubsub.kafka.properties.SubscriptionProperties;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.DeleteTopicRequest;
@@ -50,6 +44,8 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
+
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.After;
@@ -94,12 +90,19 @@ public class PublisherImplTest {
 
   @After
   public void tearDown() {
-    List<String> toRemove = Lists.newArrayList(NEW_TOPIC1);
+    List<String> toRemove =
+        Lists.newArrayList(NEW_TOPIC1, TOPIC_TO_DELETE1, SUBSCRIPTION_TO_DELETE1);
     Configuration.getApplicationProperties()
         .getKafkaProperties()
         .getProducerProperties()
         .getTopics()
         .removeIf(t -> toRemove.contains(t));
+
+    Configuration.getApplicationProperties()
+        .getKafkaProperties()
+        .getConsumerProperties()
+        .getSubscriptions()
+        .removeIf(s -> toRemove.contains(s.getName()));
 
     resetRequestBindConfiguration();
   }
@@ -166,13 +169,120 @@ public class PublisherImplTest {
   }
 
   @Test
-  public void deleteTopic() {
+  public void deleteTopicWhenTopicDoesntExist() {
     try {
-      DeleteTopicRequest request = DeleteTopicRequest.newBuilder().setTopic(TOPIC1).build();
+      DeleteTopicRequest request =
+          DeleteTopicRequest.newBuilder().setTopic(TOPIC_TO_DELETE1).build();
+
       blockingStub.deleteTopic(request);
-      fail("Topic deletion should be unavailable");
+
+      fail("Topic deletion should be unavailable.");
     } catch (StatusRuntimeException e) {
-      assertEquals(Status.UNIMPLEMENTED.getCode(), e.getStatus().getCode());
+      assertEquals(Status.NOT_FOUND.getCode(), e.getStatus().getCode());
+    } catch (Exception e) {
+      fail("Unexpected exception thrown " + e.getMessage());
+    }
+  }
+
+  @Test
+  public void deleteTopicWithNoSubscriptions() {
+    try {
+      publisher.addTopic(TOPIC_TO_DELETE1);
+
+      DeleteTopicRequest request =
+          DeleteTopicRequest.newBuilder().setTopic(TOPIC_TO_DELETE1).build();
+
+      blockingStub.deleteTopic(request);
+
+      assertFalse(
+          Configuration.getApplicationProperties()
+              .getKafkaProperties()
+              .getProducerProperties()
+              .getTopics()
+              .contains(TOPIC_TO_DELETE1));
+
+    } catch (Exception e) {
+      fail("Unexpected exception thrown " + e.getMessage());
+    }
+  }
+
+  @Test
+  public void deleteTopicWithSubscriptions() {
+    try {
+      publisher.addTopic(TOPIC_TO_DELETE1);
+      SubscriptionProperties subscriptionToDelete = new SubscriptionProperties();
+      subscriptionToDelete.setTopic(TOPIC_TO_DELETE1);
+      subscriptionToDelete.setName(SUBSCRIPTION_TO_DELETE1);
+      subscriptionToDelete.setAckDeadlineSeconds(10);
+      Configuration.getApplicationProperties()
+          .getKafkaProperties()
+          .getConsumerProperties()
+          .getSubscriptions()
+          .add(subscriptionToDelete);
+
+      DeleteTopicRequest request =
+          DeleteTopicRequest.newBuilder().setTopic(TOPIC_TO_DELETE1).build();
+
+      blockingStub.deleteTopic(request);
+
+      assertFalse(
+          Configuration.getApplicationProperties()
+              .getKafkaProperties()
+              .getProducerProperties()
+              .getTopics()
+              .contains(TOPIC_TO_DELETE1));
+
+      assertFalse(
+          Configuration.getApplicationProperties()
+              .getKafkaProperties()
+              .getConsumerProperties()
+              .getSubscriptions()
+              .stream()
+              .anyMatch(s -> s.getTopic().equals(TOPIC_TO_DELETE1)));
+
+      assertTrue(subscriptionToDelete.hasDeletedTopic());
+
+    } catch (Exception e) {
+      fail("Unexpected exception thrown " + e.getMessage());
+    }
+  }
+
+  @Test
+  public void deleteTopicWithSubscriptionsFormatted() {
+    try {
+      publisher.addTopic(TOPIC_TO_DELETE1);
+      SubscriptionProperties subscriptionToDelete = new SubscriptionProperties();
+      subscriptionToDelete.setTopic(TOPIC_TO_DELETE1);
+      subscriptionToDelete.setName(SUBSCRIPTION_TO_DELETE1);
+      subscriptionToDelete.setAckDeadlineSeconds(10);
+      Configuration.getApplicationProperties()
+          .getKafkaProperties()
+          .getConsumerProperties()
+          .getSubscriptions()
+          .add(subscriptionToDelete);
+
+      DeleteTopicRequest request =
+          DeleteTopicRequest.newBuilder().setTopic(TOPIC_TO_DELETE1_FORMATTED).build();
+
+      blockingStub.deleteTopic(request);
+
+      assertFalse(
+          Configuration.getApplicationProperties()
+              .getKafkaProperties()
+              .getProducerProperties()
+              .getTopics()
+              .contains(TOPIC_TO_DELETE1));
+
+      assertFalse(
+          Configuration.getApplicationProperties()
+              .getKafkaProperties()
+              .getConsumerProperties()
+              .getSubscriptions()
+              .stream()
+              .anyMatch(s -> s.getTopic().equals(TOPIC_TO_DELETE1)));
+
+      assertTrue(subscriptionToDelete.hasDeletedTopic());
+
     } catch (Exception e) {
       fail("Unexpected exception thrown " + e.getMessage());
     }

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/PublisherImplTest.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/PublisherImplTest.java
@@ -44,7 +44,6 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.Consumer;
 
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/TestHelpers.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/TestHelpers.java
@@ -56,6 +56,7 @@ public class TestHelpers {
   public static final String TOPIC2 = "test-topic-2";
   public static final String TOPIC2_FORMATTED = "projects/cpe-ti/topics/test-topic-2";
   public static final String TOPIC_TO_DELETE1 = "topic-to-delete1";
+  public static final String TOPIC_TO_DELETE1_FORMATTED = "projects/cpe-ti/topics/topic-to-delete1";
   public static final String TOPIC_TO_DELETE2 = "topic-to-delete2";
   public static final String TOPIC_NOT_EXISTS = "non-existent-topic";
   private static final String CONFIGURATION_UNIT_TEST =
@@ -139,6 +140,7 @@ public class TestHelpers {
             givenPubSubBindProperty(SUBSCRIPTION1, TOPIC2),
             givenPubSubBindProperty(NEW_SUBSCRIPTION2, TOPIC2),
             givenPubSubBindProperty("", NEW_TOPIC1),
+            givenPubSubBindProperty("", TOPIC_TO_DELETE1),
             givenPubSubBindProperty(SUBSCRIPTION_TO_DELETE2_FORMATTED, TOPIC_TO_DELETE2)));
     Configuration.getApplicationProperties().setPubSubProperties(pubSubProperties);
   }

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/TestHelpers.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/TestHelpers.java
@@ -45,6 +45,8 @@ public class TestHelpers {
   public static final String NEW_SUBSCRIPTION2 = "new-subscription2";
   public static final String NEW_SUBSCRIPTION2_FORMATTED =
       "projects/cpe-ti/subscriptions/new-subscription2";
+  public static final String NEW_TOPIC1 = "new-topic";
+  public static final String NEW_TOPIC1_FORMATTED = "projects/cpe-ti/topics/new-topic";
   public static final String SUBSCRIPTION_NOT_EXISTS = "non-existent-subscription";
   public static final String SUBSCRIPTION_TO_DELETE1 = "subscription-to-delete-1";
   public static final String SUBSCRIPTION_TO_DELETE2 = "subscription-to-delete-2";
@@ -136,6 +138,7 @@ public class TestHelpers {
         newArrayList(
             givenPubSubBindProperty(SUBSCRIPTION1, TOPIC2),
             givenPubSubBindProperty(NEW_SUBSCRIPTION2, TOPIC2),
+            givenPubSubBindProperty("", NEW_TOPIC1),
             givenPubSubBindProperty(SUBSCRIPTION_TO_DELETE2_FORMATTED, TOPIC_TO_DELETE2)));
     Configuration.getApplicationProperties().setPubSubProperties(pubSubProperties);
   }


### PR DESCRIPTION
This PR implements `createTopic` and `deleteTopic` and introduces relative tests.

Topics with the same name across projects will most likely cause clashes as per issue #6. I didn't want to address this issue in this PR because it needs more design considerations and would have made the change set too large.