### PR TITLE
Prepend project id to each kafkaTopic

### DIFF
--- a/src/main/java/com/google/cloud/partners/pubsub/kafka/config/ConfigurationManager.java
+++ b/src/main/java/com/google/cloud/partners/pubsub/kafka/config/ConfigurationManager.java
@@ -169,7 +169,7 @@ public final class ConfigurationManager {
     }
     com.google.pubsub.v1.Topic.Builder builder = topic.toBuilder();
     if (topic.getLabelsOrDefault(KAFKA_TOPIC, null) == null) {
-      builder.putLabels(KAFKA_TOPIC, projectTopicName.getTopic()).build();
+      builder.putLabels(KAFKA_TOPIC, projectTopicName.getProject() + "_" + projectTopicName.getTopic()).build();
     }
 
     com.google.pubsub.v1.Topic built = builder.build();

--- a/src/main/java/com/google/cloud/partners/pubsub/kafka/config/ConfigurationManager.java
+++ b/src/main/java/com/google/cloud/partners/pubsub/kafka/config/ConfigurationManager.java
@@ -45,6 +45,7 @@ import javax.inject.Singleton;
 public final class ConfigurationManager {
 
   public static final String KAFKA_TOPIC = "kafka-topic";
+  public static final String KAFKA_TOPIC_SEPARATOR = ".";
 
   private final SetMultimap<String, com.google.pubsub.v1.Topic> topicsByProject =
       Multimaps.synchronizedSetMultimap(HashMultimap.create());
@@ -169,7 +170,10 @@ public final class ConfigurationManager {
     }
     com.google.pubsub.v1.Topic.Builder builder = topic.toBuilder();
     if (topic.getLabelsOrDefault(KAFKA_TOPIC, null) == null) {
-      builder.putLabels(KAFKA_TOPIC, projectTopicName.getProject() + "_" + projectTopicName.getTopic()).build();
+      builder.putLabels(
+          KAFKA_TOPIC,
+          String.join(
+              KAFKA_TOPIC_SEPARATOR, projectTopicName.getProject(), projectTopicName.getTopic()));
     }
 
     com.google.pubsub.v1.Topic built = builder.build();

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/PublisherServiceTest.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/PublisherServiceTest.java
@@ -107,7 +107,7 @@ public class PublisherServiceTest {
   @Test
   public void createTopic() {
     Topic request = Topic.newBuilder().setName("projects/project-1/topics/new-topic").build();
-    Topic expected = request.toBuilder().putLabels(KAFKA_TOPIC, "new-topic").build();
+    Topic expected = request.toBuilder().putLabels(KAFKA_TOPIC, "project-1_new-topic").build();
 
     assertThat(blockingStub.createTopic(request), Matchers.equalTo(expected));
   }
@@ -319,11 +319,11 @@ public class PublisherServiceTest {
     assertThat(
         topics,
         Matchers.contains(
-            "implicit-kafka-topic",
-            "implicit-kafka-topic",
-            "implicit-kafka-topic",
-            "implicit-kafka-topic",
-            "implicit-kafka-topic"));
+            "project-1_implicit-kafka-topic",
+            "project-1_implicit-kafka-topic",
+            "project-1_implicit-kafka-topic",
+            "project-1_implicit-kafka-topic",
+            "project-1_implicit-kafka-topic"));
     assertThat(
         data, Matchers.contains("message-0", "message-1", "message-2", "message-3", "message-4"));
 

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/PublisherServiceTest.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/PublisherServiceTest.java
@@ -76,6 +76,7 @@ public class PublisherServiceTest {
   private static final ScheduledExecutorService PUBLISH_EXECUTOR =
       Executors.newSingleThreadScheduledExecutor();
   private static final String KAFKA_TOPIC = "kafka-topic";
+  private static final String KAFKA_TOPIC_SEPARATOR = ConfigurationManager.KAFKA_TOPIC_SEPARATOR;
 
   @Rule public final GrpcServerRule grpcServerRule = new GrpcServerRule().directExecutor();
   @Rule public final ExpectedException expectedException = ExpectedException.none();
@@ -107,7 +108,8 @@ public class PublisherServiceTest {
   @Test
   public void createTopic() {
     Topic request = Topic.newBuilder().setName("projects/project-1/topics/new-topic").build();
-    Topic expected = request.toBuilder().putLabels(KAFKA_TOPIC, "project-1_new-topic").build();
+    Topic expected = request.toBuilder().putLabels(KAFKA_TOPIC,
+            "project-1" + KAFKA_TOPIC_SEPARATOR + "new-topic").build();
 
     assertThat(blockingStub.createTopic(request), Matchers.equalTo(expected));
   }
@@ -319,11 +321,11 @@ public class PublisherServiceTest {
     assertThat(
         topics,
         Matchers.contains(
-            "project-1_implicit-kafka-topic",
-            "project-1_implicit-kafka-topic",
-            "project-1_implicit-kafka-topic",
-            "project-1_implicit-kafka-topic",
-            "project-1_implicit-kafka-topic"));
+            "project-1" + KAFKA_TOPIC_SEPARATOR + "implicit-kafka-topic",
+            "project-1" + KAFKA_TOPIC_SEPARATOR + "implicit-kafka-topic",
+            "project-1" + KAFKA_TOPIC_SEPARATOR + "implicit-kafka-topic",
+            "project-1" + KAFKA_TOPIC_SEPARATOR + "implicit-kafka-topic",
+            "project-1" + KAFKA_TOPIC_SEPARATOR + "implicit-kafka-topic"));
     assertThat(
         data, Matchers.contains("message-0", "message-1", "message-2", "message-3", "message-4"));
 

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/config/ConfigurationManagerTest.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/config/ConfigurationManagerTest.java
@@ -165,7 +165,7 @@ public class ConfigurationManagerTest {
         Matchers.contains(
             com.google.pubsub.v1.Topic.newBuilder()
                 .setName("projects/project-1/topics/a-new-topic")
-                .putLabels(KAFKA_TOPIC, "a-new-topic")
+                .putLabels(KAFKA_TOPIC, "project-1_a-new-topic")
                 .build(),
             com.google.pubsub.v1.Topic.newBuilder()
                 .setName("projects/project-1/topics/topic-1")

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/config/ConfigurationManagerTest.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/config/ConfigurationManagerTest.java
@@ -17,6 +17,7 @@ public class ConfigurationManagerTest {
   @Rule public ExpectedException expectedException = ExpectedException.none();
   private FakePubSubRepository fakePubSubRepository = new FakePubSubRepository();
   private ConfigurationManager configurationManager;
+  private static final String KAFKA_TOPIC_SEPARATOR = ConfigurationManager.KAFKA_TOPIC_SEPARATOR;
 
   @Before
   public void setUp() {
@@ -165,7 +166,7 @@ public class ConfigurationManagerTest {
         Matchers.contains(
             com.google.pubsub.v1.Topic.newBuilder()
                 .setName("projects/project-1/topics/a-new-topic")
-                .putLabels(KAFKA_TOPIC, "project-1_a-new-topic")
+                .putLabels(KAFKA_TOPIC, "project-1" + KAFKA_TOPIC_SEPARATOR + "a-new-topic")
                 .build(),
             com.google.pubsub.v1.Topic.newBuilder()
                 .setName("projects/project-1/topics/topic-1")


### PR DESCRIPTION
This PR fixes issue #18 by prepending the project name to the topic name in `kafkaTopic` label.
The project name and topic name are separated by a `.` character.

#### Note about separator

The `.` is a compromise based on valid characters according to:

* GCP Projects [restrictions](https://cloud.google.com/resource-manager/reference/rest/v1beta1/projects): 
> It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. 
* PubSub Topics [restrictions](https://github.com/googleapis/googleapis/blob/master/google/pubsub/v1/pubsub.proto#L125):
 > // The name of the topic. It must have the format
 > // `"projects/{project}/topics/{topic}"`. `{topic}` must start with a letter,
 > // and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`),
 > // underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent
 > // signs (`%`). It must be between 3 and 255 characters in length, and it
 > // must not start with `"goog"`.
* Kafka Topics [restrictions](https://github.com/apache/kafka/blob/0.10.2/core/src/main/scala/kafka/common/Topic.scala#L29)
> any string of length: 1-249 composed by "[a-zA-Z0-9\\._\\-]" and "+" characters
> except "." and ".."

Using `.` will allow to extract project and topic names by splitting on the first occurrence.

The allowed length for a topic would be shorter but still reasonable: `len(projectID) + len(topicName) + 1 < 249`

It is useful to programmatically know the underlying kafkaTopic without too much knowledge of the emulator implementation. As an example use case, we would like to use the kafkaTopic in [Kafka Connect](https://docs.confluent.io/current/connect/index.html) to integrate pubsub messages from the emulator in a larger messaging infrastructure.

For this reason I would prefer `{project}.{topic}` over a `UUID` which, however, might have other advantages.

