### PR TITLE
Fix missing push config

### DIFF
--- a/src/main/java/com/google/cloud/partners/pubsub/kafka/config/ConfigurationManager.java
+++ b/src/main/java/com/google/cloud/partners/pubsub/kafka/config/ConfigurationManager.java
@@ -220,9 +220,9 @@ public final class ConfigurationManager {
     com.google.pubsub.v1.Subscription.Builder builder =
         subscription.toBuilder().putLabels(KAFKA_TOPIC, topic.getLabelsOrThrow(KAFKA_TOPIC));
     if (subscription.getAckDeadlineSeconds() == 0) {
-      builder.setAckDeadlineSeconds(10).build();
+      builder.setAckDeadlineSeconds(10);
     }
-    builder.setPushConfig(PushConfig.getDefaultInstance());
+    builder.setPushConfig(PushConfig.getDefaultInstance()).build();
     com.google.pubsub.v1.Subscription built = builder.build();
     subscriptionsByProject.put(
         ProjectName.of(projectSubscriptionName.getProject()).toString(), built);

--- a/src/main/java/com/google/cloud/partners/pubsub/kafka/config/ConfigurationManager.java
+++ b/src/main/java/com/google/cloud/partners/pubsub/kafka/config/ConfigurationManager.java
@@ -26,6 +26,8 @@ import com.google.protobuf.util.JsonFormat;
 import com.google.pubsub.v1.ProjectName;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.ProjectTopicName;
+import com.google.pubsub.v1.PushConfig;
+
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -82,6 +84,7 @@ public final class ConfigurationManager {
                   .setTopic(topicName)
                   .setName(ProjectSubscriptionName.format(p.getName(), s.getName()))
                   .setAckDeadlineSeconds(s.getAckDeadlineSeconds())
+                  .setPushConfig(PushConfig.getDefaultInstance())
                   .putLabels(KAFKA_TOPIC, kafkaTopic)
                   .build());
         }
@@ -219,6 +222,7 @@ public final class ConfigurationManager {
     if (subscription.getAckDeadlineSeconds() == 0) {
       builder.setAckDeadlineSeconds(10).build();
     }
+    builder.setPushConfig(PushConfig.getDefaultInstance());
     com.google.pubsub.v1.Subscription built = builder.build();
     subscriptionsByProject.put(
         ProjectName.of(projectSubscriptionName.getProject()).toString(), built);

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/SubscriberServiceTest.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/SubscriberServiceTest.java
@@ -40,6 +40,7 @@ import com.google.pubsub.v1.ModifyAckDeadlineRequest;
 import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.PullRequest;
 import com.google.pubsub.v1.PullResponse;
+import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.ReceivedMessage;
 import com.google.pubsub.v1.StreamingPullRequest;
 import com.google.pubsub.v1.StreamingPullResponse;
@@ -123,6 +124,7 @@ public class SubscriberServiceTest {
             .toBuilder()
             .setAckDeadlineSeconds(10)
             .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+            .setPushConfig(PushConfig.getDefaultInstance())
             .build();
     SubscriptionManager fakeSubscriptionManager =
         new FakeSubscriptionManager(
@@ -203,6 +205,7 @@ public class SubscriberServiceTest {
                 .setName(TestHelpers.PROJECT1_SUBSCRIPTION1)
                 .setTopic(TestHelpers.PROJECT1_TOPIC1)
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(10)
                 .build()));
   }
@@ -232,12 +235,14 @@ public class SubscriberServiceTest {
                 .setName(TestHelpers.PROJECT1_SUBSCRIPTION1)
                 .setTopic(TestHelpers.PROJECT1_TOPIC1)
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(10)
                 .build(),
             Subscription.newBuilder()
                 .setName(TestHelpers.PROJECT1_SUBSCRIPTION2)
                 .setTopic(TestHelpers.PROJECT1_TOPIC1)
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(30)
                 .build()));
   }
@@ -258,6 +263,7 @@ public class SubscriberServiceTest {
                 .setName(TestHelpers.PROJECT1_SUBSCRIPTION1)
                 .setTopic(TestHelpers.PROJECT1_TOPIC1)
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(10)
                 .build()));
     assertThat(response.getNextPageToken(), Matchers.not(Matchers.isEmptyOrNullString()));
@@ -271,6 +277,7 @@ public class SubscriberServiceTest {
                 .setName(TestHelpers.PROJECT1_SUBSCRIPTION2)
                 .setTopic(TestHelpers.PROJECT1_TOPIC1)
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(30)
                 .build()));
     assertThat(response.getNextPageToken(), Matchers.isEmptyOrNullString());
@@ -771,6 +778,7 @@ public class SubscriberServiceTest {
             .setName(TestHelpers.PROJECT1_SUBSCRIPTION1)
             .setTopic(TestHelpers.PROJECT1_TOPIC1)
             .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+            .setPushConfig(PushConfig.getDefaultInstance())
             .setAckDeadlineSeconds(10)
             .build();
     Subscription subscription2 =
@@ -778,6 +786,7 @@ public class SubscriberServiceTest {
             .setName(TestHelpers.PROJECT1_SUBSCRIPTION2)
             .setTopic(TestHelpers.PROJECT1_TOPIC1)
             .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+            .setPushConfig(PushConfig.getDefaultInstance())
             .setAckDeadlineSeconds(30)
             .build();
     Subscription subscription3 =
@@ -785,6 +794,7 @@ public class SubscriberServiceTest {
             .setName(TestHelpers.PROJECT2_SUBSCRIPTION3)
             .setTopic("projects/project-2/topics/topic-2")
             .putLabels(KAFKA_TOPIC, "kafka-topic-2")
+            .setPushConfig(PushConfig.getDefaultInstance())
             .setAckDeadlineSeconds(45)
             .build();
 

--- a/src/test/java/com/google/cloud/partners/pubsub/kafka/config/ConfigurationManagerTest.java
+++ b/src/test/java/com/google/cloud/partners/pubsub/kafka/config/ConfigurationManagerTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertThat;
 import com.google.cloud.partners.pubsub.kafka.TestHelpers;
 import com.google.cloud.partners.pubsub.kafka.config.ConfigurationManager.ConfigurationAlreadyExistsException;
 import com.google.cloud.partners.pubsub.kafka.config.ConfigurationManager.ConfigurationNotFoundException;
+import com.google.pubsub.v1.PushConfig;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
@@ -72,24 +73,28 @@ public class ConfigurationManagerTest {
                 .setName("projects/project-1/subscriptions/subscription-1")
                 .setTopic("projects/project-1/topics/topic-1")
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(10)
                 .build(),
             com.google.pubsub.v1.Subscription.newBuilder()
                 .setName("projects/project-1/subscriptions/subscription-2")
                 .setTopic("projects/project-1/topics/topic-1")
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(10)
                 .build(),
             com.google.pubsub.v1.Subscription.newBuilder()
                 .setName("projects/project-1/subscriptions/subscription-3")
                 .setTopic("projects/project-1/topics/topic-2")
                 .putLabels(KAFKA_TOPIC, "kafka-topic-2")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(30)
                 .build(),
             com.google.pubsub.v1.Subscription.newBuilder()
                 .setName("projects/project-1/subscriptions/subscription-4")
                 .setTopic("projects/project-1/topics/topic-2")
                 .putLabels(KAFKA_TOPIC, "kafka-topic-2")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(45)
                 .build()));
     assertThat(
@@ -99,17 +104,20 @@ public class ConfigurationManagerTest {
                 .setName("projects/project-2/subscriptions/subscription-1")
                 .setTopic("projects/project-2/topics/topic-1")
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(10)
                 .build(),
             com.google.pubsub.v1.Subscription.newBuilder()
                 .setName("projects/project-2/subscriptions/subscription-2")
                 .setTopic("projects/project-2/topics/topic-1")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
                 .setAckDeadlineSeconds(10)
                 .build(),
             com.google.pubsub.v1.Subscription.newBuilder()
                 .setName("projects/project-2/subscriptions/subscription-3")
                 .setTopic("projects/project-2/topics/topic-2")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .putLabels(KAFKA_TOPIC, "kafka-topic-2")
                 .setAckDeadlineSeconds(30)
                 .build()));
@@ -130,11 +138,13 @@ public class ConfigurationManagerTest {
                 .setTopic("projects/project-1/topics/topic-1")
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
                 .setAckDeadlineSeconds(10)
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .build(),
             com.google.pubsub.v1.Subscription.newBuilder()
                 .setName("projects/project-1/subscriptions/subscription-2")
                 .setTopic("projects/project-1/topics/topic-1")
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(10)
                 .build()));
     assertThat(
@@ -144,12 +154,14 @@ public class ConfigurationManagerTest {
                 .setName("projects/project-2/subscriptions/subscription-1")
                 .setTopic("projects/project-2/topics/topic-1")
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(10)
                 .build(),
             com.google.pubsub.v1.Subscription.newBuilder()
                 .setName("projects/project-2/subscriptions/subscription-2")
                 .setTopic("projects/project-2/topics/topic-1")
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(10)
                 .build()));
   }
@@ -227,30 +239,35 @@ public class ConfigurationManagerTest {
                 .setName("projects/project-1/subscriptions/new-subscription")
                 .setTopic("projects/project-1/topics/topic-1")
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(10)
                 .build(),
             com.google.pubsub.v1.Subscription.newBuilder()
                 .setName("projects/project-1/subscriptions/subscription-1")
                 .setTopic("projects/project-1/topics/topic-1")
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(10)
                 .build(),
             com.google.pubsub.v1.Subscription.newBuilder()
                 .setName("projects/project-1/subscriptions/subscription-2")
                 .setTopic("projects/project-1/topics/topic-1")
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(10)
                 .build(),
             com.google.pubsub.v1.Subscription.newBuilder()
                 .setName("projects/project-1/subscriptions/subscription-3")
                 .setTopic("projects/project-1/topics/topic-2")
                 .putLabels(KAFKA_TOPIC, "kafka-topic-2")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(30)
                 .build(),
             com.google.pubsub.v1.Subscription.newBuilder()
                 .setName("projects/project-1/subscriptions/subscription-4")
                 .setTopic("projects/project-1/topics/topic-2")
                 .putLabels(KAFKA_TOPIC, "kafka-topic-2")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(45)
                 .build()));
   }
@@ -294,6 +311,7 @@ public class ConfigurationManagerTest {
                 .setName("projects/project-2/subscriptions/subscription-1")
                 .setTopic("projects/project-2/topics/topic-1")
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .setAckDeadlineSeconds(10)
                 .build(),
             com.google.pubsub.v1.Subscription.newBuilder()
@@ -301,6 +319,7 @@ public class ConfigurationManagerTest {
                 .setTopic("projects/project-2/topics/topic-1")
                 .putLabels(KAFKA_TOPIC, "kafka-topic-1")
                 .setAckDeadlineSeconds(10)
+                .setPushConfig(PushConfig.getDefaultInstance())
                 .build()));
   }
 


### PR DESCRIPTION
Fix for issue #20 and #9.

Simply introduce `getDefaultInstance` for `PushConfig` fields in subscriptions.