### PR TITLE
Remove reference to standalone cobra cli

### DIFF
--- a/go/src/kafka-pubsub-emulator-gateway/build.sh
+++ b/go/src/kafka-pubsub-emulator-gateway/build.sh
@@ -28,7 +28,7 @@ clean() {
 }
 
 build_proto_files(){
-  go get -u -v github.com/spf13/cobra/cobra && \
+  go get -u -v github.com/spf13/cobra && \
   go get -u -v google.golang.org/grpc && \
   go get -u -v github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway && \
   go get -u -v github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger && \


### PR DESCRIPTION
Switches the `go get` command to use the cobra library instead of the `cobra/cobra` command, since the command is being removed from the github.com/spf13/cobra module (xref https://github.com/spf13/cobra/issues/1597)